### PR TITLE
Fixed to compile errors

### DIFF
--- a/urdf_to_simox_xml/README.md
+++ b/urdf_to_simox_xml/README.md
@@ -1,5 +1,10 @@
-How to run the URDF to Simox XML converter.
+It needs to have meshlab installed: 
+```
+sudo apt-get install meshlab
+```
 
+How to run the URDF to Simox XML converter.
+```
 $ cd ~/catkin_ws
 $ ls
 build devel src
@@ -9,21 +14,23 @@ $ catkin_make
 $ source devel/setup.bash
 $ rospack find urdf_to_simox_xml
 $ rosrun urdf_to_simox_xml urdf_to_simox_xml --help
-
+```
 ---------
+The output_dir should point to the path where the *model* folder with the .wrl files are located. For example, to generate the model of the shadow hand:
+rosrun urdf_to_simox_xml urdf_to_simox_xml --output_dir simox_ros/sr_grasp_description/simox
 
 Use RobotViewer to verify the output (xml files such as shadowhand.xml and dms.xml):
-
+```
 $ RobotViewer
-
+```
 Click on the "Select Robot File" button on the panel, and select the xml file.
 
 Note that RobotViewer is part of http://simox.sourceforge.net. If you cannot find it, make sure that you have installed SoQt library before installing Simox.
 
 To grasp an object with the hand (e.g., the DMS hand), run GraspPlanner (also part of Simox).
-
+```
 $ GraspPlanner --robot dms.xml --endeffector "DMS Hand" --preshape "Grasp Preshape"
-
+```
 Note that all preshape values are set to zero by the converter. Update them before you run the grasp planner (especially the values for the thumb). Inside the Preshape node, update also the values of the Actor nodes.
 
 ---------

--- a/urdf_to_simox_xml/README.md
+++ b/urdf_to_simox_xml/README.md
@@ -1,27 +1,17 @@
-It needs to have meshlab installed: 
-```
-sudo apt-get install meshlab
-```
-
 How to run the URDF to Simox XML converter.
 ```
-$ cd ~/catkin_ws
-$ ls
-build devel src
-$ ls src/
-CMakeLists.txt README.md urdf_to_simox_xml
-$ catkin_make
-$ source devel/setup.bash
-$ rospack find urdf_to_simox_xml
-$ rosrun urdf_to_simox_xml urdf_to_simox_xml --help
+catkin_make
+source devel/setup.bash
+rospack find urdf_to_simox_xml
+rosrun urdf_to_simox_xml urdf_to_simox_xml --help
 ```
 ---------
 The output_dir should point to the path where the *model* folder with the .wrl files are located. For example, to generate the model of the shadow hand:
-rosrun urdf_to_simox_xml urdf_to_simox_xml --output_dir simox_ros/sr_grasp_description/simox
+rosrun urdf_to_simox_xml urdf_to_simox_xml --output_dir src/simox_ros/sr_grasp_description/simox
 
 Use RobotViewer to verify the output (xml files such as shadowhand.xml and dms.xml):
 ```
-$ RobotViewer
+RobotViewer
 ```
 Click on the "Select Robot File" button on the panel, and select the xml file.
 
@@ -29,7 +19,7 @@ Note that RobotViewer is part of http://simox.sourceforge.net. If you cannot fin
 
 To grasp an object with the hand (e.g., the DMS hand), run GraspPlanner (also part of Simox).
 ```
-$ GraspPlanner --robot dms.xml --endeffector "DMS Hand" --preshape "Grasp Preshape"
+GraspPlanner --robot dms.xml --endeffector "DMS Hand" --preshape "Grasp Preshape"
 ```
 Note that all preshape values are set to zero by the converter. Update them before you run the grasp planner (especially the values for the thumb). Inside the Preshape node, update also the values of the Actor nodes.
 

--- a/urdf_to_simox_xml/include/urdf_to_simox_xml/urdf_to_simox_xml.hpp
+++ b/urdf_to_simox_xml/include/urdf_to_simox_xml/urdf_to_simox_xml.hpp
@@ -16,6 +16,7 @@
 
 #include <string>
 
+#include <boost/foreach.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/xml_parser.hpp>
 #include <boost/scoped_ptr.hpp>

--- a/urdf_to_simox_xml/package.xml
+++ b/urdf_to_simox_xml/package.xml
@@ -23,4 +23,6 @@
   <run_depend>roslib</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>urdf</run_depend>
+  <run_depend>meshlab</run_depend>
+  
 </package>

--- a/urdf_to_simox_xml/src/urdf_to_simox_xml.cpp
+++ b/urdf_to_simox_xml/src/urdf_to_simox_xml.cpp
@@ -23,7 +23,6 @@
 #include <string>
 #include <sstream>
 #include <vector>
-#include <boost/foreach.hpp>
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/iter_find.hpp>
 #include <boost/filesystem/operations.hpp>


### PR DESCRIPTION
This package was giving errors because of the order of an include, which was solved. Also improved the README file.